### PR TITLE
Remove Bootstrap JS CDN reference in CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,4 +4,4 @@
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
 
-  Content-Security-Policy: default-src 'none'; base-uri 'none'; connect-src 'self' https://api.dribbble.com/v2/user/shots; font-src 'self'; img-src 'self' https://cdn.dribbble.com; manifest-src 'self'; object-src 'none'; script-src 'self' https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/ https://absorbed-andesaurus.glitch.me/; style-src 'self'; 
+  Content-Security-Policy: default-src 'none'; base-uri 'none'; connect-src 'self' https://api.dribbble.com/v2/user/shots; font-src 'self'; img-src 'self' https://cdn.dribbble.com; manifest-src 'self'; object-src 'none'; script-src 'self' https://absorbed-andesaurus.glitch.me/; style-src 'self'; 


### PR DESCRIPTION
Fixes #41

- Pull Bootstrap JS CDN exception