### PR TITLE
add require-trusted-types

### DIFF
--- a/accouterments/_headers
+++ b/accouterments/_headers
@@ -4,4 +4,4 @@
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
 
-  Content-Security-Policy: default-src 'none'; base-uri 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; img-src 'self' https://cdn.dribbble.com; manifest-src 'self'; object-src 'none'; script-src 'self'; style-src 'self'; 
+  Content-Security-Policy: default-src 'none'; base-uri 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; img-src 'self' https://cdn.dribbble.com; manifest-src 'self'; object-src 'none'; script-src 'self'; style-src 'self'; require-trusted-types-for 'script'; 


### PR DESCRIPTION
- follow up to enabling [Netlify CSP Integration](https://www.netlify.com/blog/general-availability-content-security-policy-csp-nonce-integration/)

- set `require-trusted-types-for 'script';` on `Content-Security-Policy` as recomended by [CSP Evaluator](https://csp-evaluator.withgoogle.com/)