### PR TITLE
update X-XSS-Protection setting

### DIFF
--- a/accouterments/_headers
+++ b/accouterments/_headers
@@ -1,7 +1,7 @@
 # set headers for netlify
 /*
   X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
+  X-XSS-Protection: 0
   X-Content-Type-Options: nosniff
 
   Content-Security-Policy: default-src 'none'; base-uri 'none'; child-src 'none'; connect-src 'self'; font-src 'self'; img-src 'self' https://cdn.dribbble.com; manifest-src 'self'; object-src 'none'; script-src 'self'; style-src 'self'; require-trusted-types-for 'script'; 


### PR DESCRIPTION
- change `X-Xss-Protection: 1; mode=block` to `X-Xss-Protection: 0`
- addresses issues raised by [hardenize.com](https://www.hardenize.com/) audit: "XSS auditor blocking is dangerous Your configuration requests blocking when XSS attacks are detected, which is potentially dangerous as it allows attackers to selectively disable portions of JavaScript code. The only safe approach is to explicitly disable browser-based XSS protection."
- confirmed known issue on [MDN X-XSS-Protection docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)